### PR TITLE
Issue133 - Usability enhancements around service publish / update.

### DIFF
--- a/public/js/app/app.js
+++ b/public/js/app/app.js
@@ -33,8 +33,8 @@ var mockapp = angular.module('mockapp',['mockapp.controllers','mockapp.services'
                     }]
                 }
             })
-
-            .when("/update/:id", {
+            
+            .when("/update/:id/:frmWher", {
                 templateUrl: "partials/updateForm.html",
                 controller: "updateController",
                 resolve: {

--- a/public/js/app/controllers.js
+++ b/public/js/app/controllers.js
@@ -380,7 +380,22 @@ var ctrl = angular.module("mockapp.controllers",['mockapp.services','mockapp.fac
             $scope.totalDisplayed += 10;
           };
 
-
+          //To Show Service Success Modal when a new service is created.
+          if($routeParams.frmWher=='frmServCreate'){
+            $http.get('/api/services/' + $routeParams.id)
+              .then(function(response) {
+                  var data = response.data;
+                  console.log(data);
+                  feedbackService.displayServiceInfo(data);
+              })
+              .catch(function(err) {
+                  console.log(err);
+                    $('#genricMsg-dialog').find('.modal-title').text(ctrlConstants.PUB_FAIL_ERR_TITLE);
+                    $('#genricMsg-dialog').find('.modal-body').text(ctrlConstants.PUB_FAIL_ERR_BODY);
+                    $('#genricMsg-dialog').modal('toggle');
+              });
+            $('#success-modal').modal('toggle');
+          }
     }])
 
 

--- a/public/js/app/services.js
+++ b/public/js/app/services.js
@@ -120,8 +120,8 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
           };
     }])
 
-    .service('apiHistoryService', ['$http', 'authService', 'feedbackService', 'xmlService', 'servConstants', 
-        function($http, authService, feedbackService, xmlService, servConstants) {
+    .service('apiHistoryService', ['$http', '$location', 'authService', 'feedbackService', 'xmlService', 'servConstants', 
+        function($http, $location, authService, feedbackService, xmlService, servConstants) {
             this.getServiceForSUT = function(name) {
                 return $http.get('/api/services/sut/' + name);
             };
@@ -305,18 +305,17 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
                 // update => put (create => post)
                 if (!isUpdate) {
                   $http.post('/api/services?token=' + token, servData)
-
                   .then(function(response) {
                       var data = response.data;
-					            console.log(data);
+                      console.log(data);
                       if(data.error == 'twoSeviceDiffNameSameBasePath'){
                       $('#genricMsg-dialog').find('.modal-title').text(servConstants.PUB_FAIL_ERR_TITLE);
                       $('#genricMsg-dialog').find('.modal-body').text(servConstants.TWOSRVICE_DIFFNAME_SAMEBP_ERR_BODY);
                       $('#genricMsg-dialog').modal('toggle');
                       }
                       else{
-                      feedbackService.displayServiceInfo(data);
-                      $('#success-modal').modal('toggle');
+                      var data = response.data;
+                      $location.path('/update/' + data._id + '/frmServCreate');
                     }
                   })
 
@@ -403,9 +402,7 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
             var data = response.data;
             console.log(data);
             //redirect to update page for created service
-            $location.path('/update/' + data._id);
-            feedbackService.displayServiceInfo(data);
-            $('#success-modal').modal('toggle');
+            $location.path('/update/' + data._id + '/frmServCreate');
           })
           .catch(function(err){
             console.log(err);

--- a/public/partials/servicehistory.html
+++ b/public/partials/servicehistory.html
@@ -29,7 +29,7 @@
                 <th>Action</th>
             </tr>
             <tr ng-repeat="service in servicelist" style=" word-break:break-all">
-                <td style="width:120px"><a href="#!update/{{ service._id }}">{{service.name}}</a></td>
+                <td style="width:120px"><a href="#!update/{{ service._id }}/frmServHistory">{{service.name}}</a></td>
                 <td>{{service.user.uid}}</td>
                 <td style="width:120px">{{service.sut.name}}</td>
                 <td>{{service.type}}</td>


### PR DESCRIPTION
Completed it for all service type wsdl/openapi and Rest/SOAP.  

1. After every service creation page redirect to update service page.
2. After landing on update page user see the success service creation messgae diaolg box.
3. Calling dialog box happening in update controller at centralized location.
4. In update controller I am getting url parameter about "from where this is getting called" if update controller is getting called from service (any) creation then I show the service create success dialog box. If update controller is getting called from service history page then It is same as before.