### PR TITLE
Fix for lastUpdateUser not being set + unset field causing errors

### DIFF
--- a/controllers/serviceController.js
+++ b/controllers/serviceController.js
@@ -538,6 +538,7 @@ function publishUploadedSpec(req, res) {
     serv.name = name;
     serv.basePath = '/' + serv.sut.name + serv.basePath;
     serv.user = req.decoded;
+    serv.lastUpdateUser = req.decoded;
 
     // save the service
     Service.create(serv, function (err, service) {

--- a/public/js/app/controllers.js
+++ b/public/js/app/controllers.js
@@ -183,10 +183,17 @@ var ctrl = angular.module("mockapp.controllers",['mockapp.services','mockapp.fac
                       delayMax: service.delayMax,
                       txnCount: service.txnCount,
                       basePath: service.basePath,
-                      createdAt: service.createdAt,
-                      updatedAt: service.updatedAt,
-                      lastUpdateUser: service.lastUpdateUser.uid
+                      
                     };
+                    if(service.lastUpdateUser){
+                      $scope.servicevo.lastUpdateUser = service.lastUpdateUser.uid;
+                    }
+                    if(service.createdAt){
+                      $scope.servicevo.createdAt = service.createdAt;
+                    }
+                    if(service.updatedAt){
+                      $scope.servicevo.updatedAt = service.updatedAt;
+                    }
 
                     $scope.servicevo.matchTemplates = [];
                     $scope.servicevo.rawpairs = [];


### PR DESCRIPTION
Quick fix for lastUpdateUser causing client js to fail if it was not present, and adding lastupdateuser logic to spec upload creation 