### PR TITLE
Live recording fixes

### DIFF
--- a/controllers/recorderController.js
+++ b/controllers/recorderController.js
@@ -193,15 +193,6 @@ function stripRRPairForReq(rrpair) {
                     },(function(error,doc){
                         if(error)
                             console.log(error);
-                        else{
-                            Recording.findOne({_id : this.model._id},(function(err,doc){
-                                if(err)
-                                    console.log(error);
-                                else{
-                                    this.model = doc;
-                                }
-                            }).bind(this));
-                        }
                     }).bind(this));
             }
 

--- a/public/js/app/controllers.js
+++ b/public/js/app/controllers.js
@@ -322,6 +322,19 @@ var ctrl = angular.module("mockapp.controllers",['mockapp.services','mockapp.fac
           ,delay);
 
         }
+
+        $scope.removeRRPair = function(index) {
+          $('#genricMsg-dialog').find('.modal-title').text(ctrlConstants.DEL_CONFIRM_TITLE);
+          $('#genricMsg-dialog').find('.modal-body').html(ctrlConstants.DEL_CONFIRM_RRPAIR_BODY);
+          $('#genricMsg-dialog').find('.modal-footer').html(ctrlConstants.DEL_CONFIRM_FOOTER);
+          $('#genricMsg-dialog').modal('toggle');
+          $scope.rrPairNo = index;
+          $('#modal-btn-yes').on("click", function () {
+              $scope.servicevo.rawpairs.splice($scope.rrPairNo,1);
+              $scope.$apply();
+            });
+        };
+        
         $scope.addTemplate = function() {
           $scope.servicevo.matchTemplates.push({ id: 0, val: '' });
         };

--- a/public/js/app/services.js
+++ b/public/js/app/services.js
@@ -122,7 +122,7 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
 
           this.displayRecorderInfo = function(data){
             $rootScope.virt.operations = [];
-            $rootScope.virt.baseUrl = '/recording/live' + data.path;
+            $rootScope.virt.baseUrl = '/recording/live/' + data.sut.name + data.path;
             $rootScope.virt.delay= data.delay;
             $rootScope.virt.delayMax= data.delayMax;
             $rootScope.virt.type = data.protocol;

--- a/public/partials/viewRecorder.html
+++ b/public/partials/viewRecorder.html
@@ -106,6 +106,12 @@
         <div class="col-xs-10">
           <h4><ins><i>Request / Response Pair</i></ins></h4>
         </div>
+
+        <div class="col-xs-1">
+            <button type="button" class="btn btn-danger" ng-click="removeRRPair($index)">
+              Delete
+            </button>
+          </div>
       </div>
 
       <div class="form-group row" ng-show="servicevo.type !== 'MQ'">


### PR DESCRIPTION
A couple simple fixes/adds for the new recording feature:

- Delete button for RR pairs (Note: This only works on the local page, refreshing will bring them back). 
- Removed spotty anti-duplicate RR pair feature (in recording only) since the delete button will handle this. Keeps the software out of the user's way. 
- Fixed recording path display on recorder start confirm modal 
