### PR TITLE
Simple CSS change to highlight invalid fields

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -125,3 +125,7 @@ input[type="radio"] {
 .blueText{
   color:blue;
 }
+
+.ng-invalid.ng-touched{
+  border-color:#f00;
+}


### PR DESCRIPTION
Super simple CSS change to highlight invalid fields in red, but only after a user has touched it

(empty fields will not show up red until after the user has changed it)