### PR TITLE
Fix for failover field control

### DIFF
--- a/public/js/app/controllers.js
+++ b/public/js/app/controllers.js
@@ -665,13 +665,23 @@ var ctrl = angular.module("mockapp.controllers",['mockapp.services','mockapp.fac
                       for(var i = 0; i < failStrings.length; i++){
                         $scope.servicevo.failStrings[i] = {'id': i, 'val' : failStrings[i]};
                       }
-
+                      if(!$scope.servicevo.failStatuses.length){
+                        $scope.servicevo.failStatuses[0] = {'id': 0,val:''};  
+                      }
+                      if(!$scope.servicevo.failStrings.length){
+                        $scope.servicevo.failStrings[0] = {'id': 0,val:''};
+                      }
                       //Select correct radio
                       if(service.liveInvocation.liveFirst)
                         $scope.servicevo.liveInvokePrePost = 'PRE';
                       else  
                         $scope.servicevo.liveInvokePrePost = 'POST';
                       
+                    }else{
+                      $scope.servicevo.failStatuses = [];
+                      $scope.servicevo.failStrings = [];
+                      $scope.servicevo.failStatuses[0] = {'id': 0,val:''};      
+                      $scope.servicevo.failStrings[0] = {'id': 0,val:''};
                     }
                     console.log($scope.servicevo);
 

--- a/public/partials/addapiform.html
+++ b/public/partials/addapiform.html
@@ -119,7 +119,7 @@
         </fieldset>
       </div>
     </div>
-    <div class="form-group row">
+    <div class="form-group row" ng-show="servicevo.type !== 'MQ'">
       <label for="live_invocation_enable" class="col-xs-2 col-form-label">Perform Live Invocation:</label>
   
       
@@ -128,7 +128,7 @@
       </div>
     </div>
     
-    <div id="live_invocation_fields"  ng-show="servicevo.liveInvocationCheck">
+    <div id="live_invocation_fields"  ng-show="servicevo.liveInvocationCheck && servicevo.type !== 'MQ'">
       
     <hr style="height:1px;border:none;color:#9f9696;background-color:#9f9696;" />
       <div class="form-group req row">
@@ -151,14 +151,14 @@
       <div class="form-group req row">
         <label for="remote_host" class="col-xs-2 col-form-label">Remote Host:</label>
         <div class="col-xs-3">
-          <input ng-required="servicevo.liveInvocationCheck" type="text" id="service_name" class="form-control" ng-model="servicevo.remoteHost" placeholder="Enter Remote Hostname">
+          <input ng-required="servicevo.liveInvocationCheck && servicevo.type !== 'MQ'" type="text" id="service_name" class="form-control" ng-model="servicevo.remoteHost" placeholder="Enter Remote Hostname">
         </div>
     
       </div>
       <div class="form-group req row">
         <label for="remote_port" class="col-xs-2 col-form-label">Remote Port:</label>
         <div class="col-xs-3">
-          <input ng-required="servicevo.liveInvocationCheck" type="text" id="service_name" class="form-control" ng-model="servicevo.remotePort" placeholder="Enter Remote Host Port">
+          <input ng-required="servicevo.liveInvocationCheck && servicevo.type !== 'MQ'" type="text" id="service_name" class="form-control" ng-model="servicevo.remotePort" placeholder="Enter Remote Host Port">
         </div>
       </div>
   

--- a/public/partials/updateForm.html
+++ b/public/partials/updateForm.html
@@ -90,7 +90,7 @@
     </div>
   </div>
 
-  <div class="form-group row">
+  <div class="form-group row" ng-show="servicevo.type !== 'MQ'">
     <label for="live_invocation_enable" class="col-xs-2 col-form-label">Perform Live Invocation:</label>
 
     
@@ -99,7 +99,7 @@
     </div>
   </div>
   
-  <div id="live_invocation_fields"  ng-show="servicevo.liveInvocationCheck">
+  <div id="live_invocation_fields"  ng-show="servicevo.liveInvocationCheck && servicevo.type !== 'MQ'">
     
   <hr style="height:1px;border:none;color:#9f9696;background-color:#9f9696;" />
     <div class="form-group req row">
@@ -122,14 +122,14 @@
     <div class="form-group req row">
       <label for="remote_host" class="col-xs-2 col-form-label">Remote Host:</label>
       <div class="col-xs-3">
-        <input ng-required="servicevo.liveInvocationCheck" type="text" id="service_name" class="form-control" ng-model="servicevo.remoteHost" placeholder="Enter Remote Hostname">
+        <input ng-required="servicevo.liveInvocationCheck && servicevo.type !== 'MQ'" type="text" id="service_name" class="form-control" ng-model="servicevo.remoteHost" placeholder="Enter Remote Hostname">
       </div>
   
     </div>
     <div class="form-group req row">
       <label for="remote_port" class="col-xs-2 col-form-label">Remote Port:</label>
       <div class="col-xs-3">
-        <input ng-required="servicevo.liveInvocationCheck" type="text" id="service_name" class="form-control" ng-model="servicevo.remotePort" placeholder="Enter Remote Host Port">
+        <input ng-required="servicevo.liveInvocationCheck && servicevo.type !== 'MQ'" type="text" id="service_name" class="form-control" ng-model="servicevo.remotePort" placeholder="Enter Remote Host Port">
       </div>
     </div>
 

--- a/routes/invoke.js
+++ b/routes/invoke.js
@@ -120,12 +120,11 @@ function mapRemoteResponseToResponse(rsp,remoteRsp,remoteBody){
  */
 function registerServiceInvoke(service){
     //Catch all paths under service basepath
-    var path = service.basePath + "/*";
+    var path = service.basePath + "/?*";
     router.all(path,function(req,rsp,next){
 
         
         if(service.liveInvocation && service.liveInvocation.enabled){
-
             //This should trigger only if it is a "pre-invoke" and the service itself doesn't catch it at all (no sub-path match)
             if(service.liveInvocation.liveFirst && !req._mockiatoLiveInvokeHasRun){
                 invokeBackendVerify(service,req).then(function(remoteRsp,remoteRspBody){
@@ -158,7 +157,7 @@ function registerServiceInvoke(service){
  * @param {*} service  Service to unregister
  */
 function deregisterServiceInvoke(service){
-    var path = service.basePath + "/*";
+    var path = service.basePath + "/?*";
     removeRoute(require('../app'), path);
 }
 


### PR DESCRIPTION
Failover fields were not being populated if the service did not previously use live invocation. This quick fix adds logic to handle that. 