### PR TITLE
Transaction counts

### DIFF
--- a/models/mq/MQService.js
+++ b/models/mq/MQService.js
@@ -23,7 +23,14 @@ const mqSchema = new mongoose.Schema({
   },
   lastUpdateUser:{
     type: User.schema
-  }
+  },
+  txnCount: {
+    type: Number,
+    default: 0,
+    get: function(v) { return Math.round(v); },
+    set: function(v) { return Math.round(v); }
+  },
+
 },{timestamps:{createdAt:'createdAt',updatedAt:'updatedAt'}});
 
 mqSchema.set('usePushEach', true);

--- a/public/partials/servicehistory.html
+++ b/public/partials/servicehistory.html
@@ -27,6 +27,7 @@
                 <th>Group</th>
                 <th>Type</th>
                 <th>Base URL</th>
+                <th>Transactions</th>
                 <th>Action</th>
             </tr>
             <tr ng-repeat="service in servicelist" style=" word-break:break-all">
@@ -35,6 +36,7 @@
                 <td style="width:120px">{{service.sut.name}}</td>
                 <td>{{service.type}}</td>
                 <td class="urlmax">{{ service.basePath ? mockiatoHost + '/virtual' + service.basePath : '' }}</td>
+                <td>{{service.txnCount}}</td>
                 <td>
                     <button class="btn btn-danger" ng-if="myGroups.includes(service.sut.name)" ng-show="service.running === true" ng-click="toggleService(service)">Stop <i class="glyphicon glyphicon-stop"></i></button>
                     <button class="btn btn-success" ng-if="myGroups.includes(service.sut.name)" ng-show="service.running === false" ng-click="toggleService(service)">Start <i class="glyphicon glyphicon-play"></i></button>&nbsp;

--- a/routes/invoke.js
+++ b/routes/invoke.js
@@ -3,6 +3,23 @@ const router = express.Router();
 const removeRoute = require('../lib/remove-route');
 const requestNode = require('request');
 
+var transactions = {};
+
+/**
+ * Log a transaction against given service
+ * @param {*} serviceId ID of the service to increment
+ */
+function incrementTransactionCount(serviceId){
+  if(transactions[serviceId]){
+    transactions[serviceId]++;
+  }else{
+    transactions[serviceId] = 1;
+  }
+  console.log(transactions);
+}
+
+
+
 /**
  * Takes a response from a remote host and maps into express's response to give to the client
  * @param {*} remoteRsp Response from remote host
@@ -126,6 +143,7 @@ function registerServiceInvoke(service){
             if(service.liveInvocation.liveFirst && !req._mockiatoLiveInvokeHasRun){
                 invokeBackendVerify(service,req).then(function(remoteRsp,remoteRspBody){
                     rsp.set('_mockiato-is-live-backend','true');
+                    incrementTransactionCount(service._id);
                     mapRemoteResponseToResponse(rsp,remoteRsp,remoteRspBody);
                 },function(err){
                     //if fails for any reason, mark error and continue
@@ -137,6 +155,7 @@ function registerServiceInvoke(service){
             }else if(!(service.liveInvocation.liveFirst)){
                 invokeBackend(service,req).then(function(remoteRsp,remoteRspBody){
                     rsp.set('_mockiato-is-live-backend','true');
+                    incrementTransactionCount(service._id);
                     mapRemoteResponseToResponse(rsp,remoteRsp,remoteRspBody);
                 },function(err){
                     //if fails for any reason, mark error and continue
@@ -168,5 +187,6 @@ module.exports = {
     invokeBackend : invokeBackend,
     invokeBackendVerify : invokeBackendVerify,
     mapRemoteResponseToResponse : mapRemoteResponseToResponse,
+    incrementTransactionCount : incrementTransactionCount,
     router : router
 };

--- a/routes/invoke.js
+++ b/routes/invoke.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const removeRoute = require('../lib/remove-route');
 const requestNode = require('request');
 const Service = require('../models/http/Service');
-const timeBetweenTransactionUpdates = 5000;
+const timeBetweenTransactionUpdates = process.env.MOCKIATO_TRANSACTON_UPDATE_TIME || 5000;
 
 var transactions = {};
 

--- a/routes/invoke.js
+++ b/routes/invoke.js
@@ -28,7 +28,6 @@ function saveTransactonCounts(){
     transactions = {};
     for(let id in myTransactions){
         Service.findByIdAndUpdate(id,{$inc:{txnCount:myTransactions[id]}}).exec();
-        MQService.findByIdAndUpdate(id,{$inc:{txnCount:myTransactions[id]}}).exec();
     }
     setTimeout(saveTransactonCounts,timeBetweenTransactionUpdates);
 }

--- a/routes/invoke.js
+++ b/routes/invoke.js
@@ -3,7 +3,6 @@ const router = express.Router();
 const removeRoute = require('../lib/remove-route');
 const requestNode = require('request');
 const Service = require('../models/http/Service');
-const MQService = require('../models/mq/MQService');
 const timeBetweenTransactionUpdates = 5000;
 
 var transactions = {};

--- a/routes/invoke.js
+++ b/routes/invoke.js
@@ -18,7 +18,6 @@ function incrementTransactionCount(serviceId){
   }else{
     transactions[serviceId] = 1;
   }
-  console.log(transactions);
 }
 
   /**

--- a/routes/virtual.js
+++ b/routes/virtual.js
@@ -8,7 +8,6 @@ const logger = require('../winston');
 const invoke = require('./invoke');
 
 
-
   
 // function to simulate latency
 function delay(ms,msMax) {
@@ -216,6 +215,7 @@ function registerRRPair(service, rrpair) {
           resp.sendStatus(200);
         }
 
+        invoke.incrementTransactionCount(service._id);
         // request was matched
         return true;
       }
@@ -269,6 +269,7 @@ function registerRRPair(service, rrpair) {
       req._mockiatoLiveInvokeHasRun = true;
       prom.then(function(remoteRsp,remoteRspBody){
         resp.set('_mockiato-is-live-backend','true');
+        invoke.incrementTransactionCount(service._id);
         invoke.mapRemoteResponseToResponse(resp,remoteRsp,remoteRspBody);
         
       },function(err){

--- a/winston.js
+++ b/winston.js
@@ -23,6 +23,6 @@ if (process.env.MOCKIATO_SPLUNK_ENABLED) {
     transports.push(new SplunkStreamEvent({ splunk: splunkSettings }));
 }
 
-logger = winston.createLogger({ format: winston.format.logstash(), transports: transports });
+logger = winston.createLogger({ transports: transports });
   
 module.exports = logger;


### PR DESCRIPTION
Adds transaction tracking in a (hopefully) performant way.

Each transaction records as a mark in memory. Every 5 seconds, if any transactions have been recorded, they will be appended to the tx count in the db. 

NOTE: This PR adds the tx count field to MQService, but will NOT track transactions on the MQ side- that has to be implemented in the MQ java app