### PR TITLE
Service create refactor

### DIFF
--- a/controllers/serviceController.js
+++ b/controllers/serviceController.js
@@ -57,7 +57,10 @@ function createService(serv,req){
     function performCreate(){
       if(serv.type == "MQ"){
         MQService.create(serv,function(err,service){
-          resolve(err,service);
+          if(err)
+            reject(err);
+          else
+            resolve(service);
         });
       }else{
         Service.create(serv,function(err,service){

--- a/controllers/systemController.js
+++ b/controllers/systemController.js
@@ -112,10 +112,32 @@ function delSystem(req, res) {
   });
 }
 
+/**
+ * Helper function to get all SUTs this user is a member of
+ * @param {string} user uid for user of interest
+ * @return mongoose query
+ */
+function findSystemsForUser(user){
+  return System.find({members:user});
+}
+
+
+/**
+ * Get a system if and ONLY if the given user is a member of that system. Otherwise return null. 
+ * @param {string} user User uid
+ * @param {string} system System name
+ * @return mongoose query
+ */
+function getSystemIfMember(user,system){
+  return System.findOne({members:user,name:system});
+}
+
 module.exports = {
   getSystems: getSystems,
   addSystem: addSystem,
   delSystem: delSystem,
   getOneSystem: getOneSystem,
-  updateGroup: updateGroup
+  updateGroup: updateGroup,
+  findSystemsForUser: findSystemsForUser,
+  getSystemIfMember : getSystemIfMember
 };

--- a/tests/test.js
+++ b/tests/test.js
@@ -42,8 +42,20 @@ function getRandomString() {
     return  Math.random().toString(36).substring(2, 15);
 }
 
+
+//Copy over mock group/user info
+mqService.user = mockUser;
+mqService.sut = mockGroup;
+restService.user = mockUser;
+restService.sut = mockGroup;
+soapService.user = mockUser;
+soapService.sut = mockGroup;
+wsdlQuery.group = mockGroup.name;
+oasQuery.group = mockGroup.name;
+
+
 describe('API tests', function() {
-    this.timeout(5000);
+    this.timeout(15000);
 
     before(function(done) {
         app.on('started', done);
@@ -67,6 +79,8 @@ describe('API tests', function() {
                 .end(done);
         });
     });
+
+    
     
     describe('Get access token', function() {
         it('Responds with the token', function(done) {
@@ -80,6 +94,16 @@ describe('API tests', function() {
         });
     });
     
+    describe('Create new group', function() {
+        it('Responds with the group', function(done) {
+            request
+                .post('/api/systems' + token)
+                .send(mockGroup)
+                .expect(200)
+                .end(done);
+        });
+    });  
+
     describe('Create REST service', function() {
         it('Responds with the new service', function(done) {
             request
@@ -104,7 +128,7 @@ describe('API tests', function() {
     describe('Test REST service', function() {
         it('Responds with the virtual data', function(done) {
             request
-                .post('/virtual/test/v2/test/resource')
+                .post('/virtual/' + mockGroup.name +  '/v2/test/resource')
                 .send({ key: 123 })
                 .expect(200)
                 .end(done);
@@ -165,7 +189,7 @@ describe('API tests', function() {
     describe('Test SOAP service', function() {
         it('Responds with the virtual data', function(done) {
             request
-                .post('/virtual/test/soap')
+                .post('/virtual/' + mockGroup.name +  '/soap')
                 .set('Content-Type', 'text/xml')
                 .send(soapService.rrpairs[0].reqData)
                 .expect(200)
@@ -200,6 +224,10 @@ describe('API tests', function() {
                 .send(mqService)
                 .expect(200)
                 .expect(function(res) {
+                    console.log("Mqreq: ");
+                    console.log(res);
+                    console.log("mqserv: ");
+                    console.log(mqService);
                     id = res.body._id;
                 }).end(done);
         });
@@ -308,15 +336,7 @@ describe('API tests', function() {
         });
     });
 
-    describe('Create new group', function() {
-        it('Responds with the group', function(done) {
-            request
-                .post('/api/systems' + token)
-                .send(mockGroup)
-                .expect(200)
-                .end(done);
-        });
-    });  
+   
     
     describe('Retrieve groups', function() {
         it('Responds with the groups', function(done) {


### PR DESCRIPTION
Refactored all service creation flows to pass through serviceController.createService. Added check to this function to ensure that the logged in user belongs to the group that this service is being added to. 