### PR TITLE
Recorder Start/Stop

### DIFF
--- a/api-docs.yml
+++ b/api-docs.yml
@@ -701,6 +701,55 @@ paths:
                 items:
                   $ref: '#/components/schemas/Recording'
                 description: successful response
+  /recording/{id}/stop:
+    patch:
+      description: Stops a recorder. A stopped recorder will not be deleted, but will not accept any more incoming requests. 
+      parameters:
+      - name: id
+        in: path
+        description: id of Recording
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      tags:
+      - recordings
+      responses:
+        200:
+          description: successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Recording'
+                description: successful response
+  /recording/{id}/start:
+   
+    patch:
+      parameters:
+      - name: id
+        in: path
+        description: id of Recording
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      description: Start a recorder, and make it accept incoming requests again. 
+      tags:
+      - recordings
+      responses:
+        200:
+          description: successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Recording'
+                description: successful response
 
   /systems:
     get:

--- a/controllers/recorderController.js
+++ b/controllers/recorderController.js
@@ -15,45 +15,71 @@ function escapeRegExp(string) {
   * Recorder object
   *
   * This object is created whenever a new recording session is started. the recording router will route all appropriate transactions to this object 
+  * Can instead pass an ID to a Recording document to 'name', and create an instance based on that recorder. 
   */
 var Recorder = function(name,path,sut,remoteHost,remotePort,protocol,headerMask,ssl){
-     this.path = path;
-     
-     //Ensure path starts with /
-    if(this.path.substring(0,1) != "/")
-        this.path = "/" + this.path;     
-   
-    this.model = Recording.create({
-        sut : {name:sut},
-        path : path,
-        remoteHost : remoteHost,
-        protocol : protocol || 'REST',
-        remotePort : remotePort || 80,
-        headerMask : headerMask || ['Content-Type'],
-        service : {
-            basePath : path.substring(1),
-            sut:{name:sut},
-            name:name,
-            type:protocol
-        },
-        name: name,
-        ssl:ssl
-    },(function(err,newModel){
-        this.model = newModel;
-        
-        if(!(this.model.headerMask))
-            this.model.headerMask = [];
-        
-        if(!(this.model.headerMask['Content-Type']))
-            this.model.headerMask.push('Content-Type');
 
-        this.model.save(function(err){
-            if(err) console.log(err);
+    var rec = this;
+    //If passed ID for Recording document...
+    if(arguments.length == 1){
+        rec.model = new Promise(function(resolve,reject){
+            Recording.findById(name,function(err,doc){
+                if(err){
+                    reject(err);
+                }else{
+                    doc.running = true;
+                    doc.save(function(err,doc){
+                        rec.model = doc;
+                        syncWorkersToNewRecorder(rec);
+                        resolve(doc);
+                    });
+                }
+
+            });
         });
-        syncWorkersToNewRecorder(this);
-    }).bind(this));
+    }else{
+
+        this.path = path;
+        
+        //Ensure path starts with /
+        if(this.path.substring(0,1) != "/")
+            this.path = "/" + this.path;     
+    
+        this.model = Recording.create({
+            sut : {name:sut},
+            path : path,
+            remoteHost : remoteHost,
+            protocol : protocol || 'REST',
+            remotePort : remotePort || 80,
+            headerMask : headerMask || ['Content-Type'],
+            service : {
+                basePath : path.substring(1),
+                sut:{name:sut},
+                name:name,
+                type:protocol
+            },
+            name: name,
+            ssl:ssl
+        },(function(err,newModel){
+            this.model = newModel;
+            
+            if(!(this.model.headerMask))
+                this.model.headerMask = [];
+            
+            if(!(this.model.headerMask['Content-Type']))
+                this.model.headerMask.push('Content-Type');
+
+            this.model.save(function(err){
+                if(err) console.log(err);
+            });
+            syncWorkersToNewRecorder(this);
+        }).bind(this));
+    }
   
  };
+
+
+
 
 function registerRecorder(recorder){
     activeRecorders[recorder.model._id] = recorder;
@@ -356,6 +382,28 @@ function removeRecorder(req,rsp){
    
 }
 
+/**
+ * API call to stop a recorder based on ID.
+ * @param {*} req  express req
+ * @param {*} rsp  express rsp
+ */
+function stopRecorder(req,rsp){
+    var recorder = activeRecorders[req.params.id];
+    if(recorder){
+        recorder.model.running = false;
+        recorder.model.save(function(err,doc){
+            rsp.status(200);
+            rsp.json(doc);
+            deregisterRecorder(recorder);
+            
+        });
+        
+    }else{
+        handleError(new Error("No recorder found for that ID or recorder is already stopped."),rsp,404);
+    }
+   
+}
+
 function deregisterRecorder(recorder){
     routing.unbindRecorder(recorder);
     if(activeRecorders[recorder.model._id])
@@ -389,6 +437,29 @@ function addRecorder(req,rsp){
 }
 
 
+ /**
+  * Starts an existing Recording into a Recorder object. 
+  * @param {string} recorderId 
+  * @return {Recorder} recorder object instantiated from Recording doc
+  */
+  function startRecorderFromId(recorderId){
+    return new Recorder(recorderId);
+}
+
+/**
+ * API call to start a recorder. :id is the id to a Recording document.  Starts up a Recorder based on the Recording doc. 
+ * @param {*} req  express req
+ * @param {*} rsp  express rsp
+ */
+function startRecorder(req,rsp){
+    startRecorderFromId(req.params.id).model.then(function(doc){
+        rsp.json(doc);
+    }).catch(function(err){
+        handleError(err,rsp,500);
+    });
+}
+
+
 
  module.exports = {
     Recorder: Recorder,
@@ -398,6 +469,8 @@ function addRecorder(req,rsp){
     getRecorderRRPairsAfter : getRecorderRRPairsAfter,
     removeRecorder: removeRecorder,
     registerRecorder: registerRecorder,
-    deregisterRecorder: deregisterRecorder
+    deregisterRecorder: deregisterRecorder,
+    startRecorder : startRecorder,
+    stopRecorder : stopRecorder
   };
   

--- a/controllers/recorderController.js
+++ b/controllers/recorderController.js
@@ -474,3 +474,14 @@ function startRecorder(req,rsp){
     stopRecorder : stopRecorder
   };
   
+
+//On startup, start all recorders that should be active.
+Recording.find({running:true},function(err,docs){
+    if(docs){
+        docs.forEach(function(doc){
+            new Recorder(doc);
+        });
+    }else if(err){
+        debug('error initializing recorders');
+    }
+});

--- a/models/http/Recording.js
+++ b/models/http/Recording.js
@@ -13,7 +13,11 @@ const recordingSchema = new mongoose.Schema({
     headerMask : Array,
     name : String,
     active : Boolean,
-    ssl : Boolean
+    ssl : Boolean,
+    running: {
+        type: Boolean,
+        default: true
+      }
 });
 
 recordingSchema.set('usePushEach', true);

--- a/public/js/app/controllers.js
+++ b/public/js/app/controllers.js
@@ -1333,6 +1333,37 @@ var ctrl = angular.module("mockapp.controllers",['mockapp.services','mockapp.fac
         $scope.recordingList = data;
       });
 
+      $scope.startRecorder = function(recorder) {
+        apiHistoryService.startRecorder(recorder)
+        .then(function(response) {
+
+            recorder.running = true;
+            recorder.active = true;
+        })
+
+        .catch(function(err) {
+            console.log(err);
+        });
+      };
+
+      $scope.stopRecorder = function(recorder) {
+        apiHistoryService.stopRecorder(recorder)
+
+        .then(function(response) {
+            recorder.running = false;
+            recorder.active = false;
+        })
+
+        .catch(function(err) {
+            //If 404, try starting, just in case.
+            console.log(err.status);
+            if(err.status == 404)
+              $scope.startRecorder(recorder);
+
+            console.log(err);
+        });
+      };
+    
 
       $scope.deleteRecording = function (recording) {
         $('#genricMsg-dialog').find('.modal-title').text(ctrlConstants.DEL_CONFIRM_TITLE);

--- a/public/js/app/services.js
+++ b/public/js/app/services.js
@@ -138,6 +138,14 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
                 return $http.get('/api/recording');
             }
 
+            this.startRecorder = function(recorder){
+              return $http.patch('/api/recording/' + recorder._id + "/start");
+            }
+
+            this.stopRecorder = function(recorder){
+              return $http.patch('/api/recording/' + recorder._id + "/stop");
+            }
+
             this.getRecordingById = function(id){
               return $http.get('/api/recording/' + id);
             }

--- a/public/js/app/services.js
+++ b/public/js/app/services.js
@@ -140,6 +140,7 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
 
             this.startRecorder = function(recorder){
               return $http.patch('/api/recording/' + recorder._id + "/start");
+              
             }
 
             this.stopRecorder = function(recorder){

--- a/public/partials/recorderList.html
+++ b/public/partials/recorderList.html
@@ -23,7 +23,6 @@
                 <th>Name</th>
                 <th>Group</th>
                 <th>Type</th>
-                <th>Active</th>
                 <th>Base URL</th>
                 <th>Delete</th>
             </tr>
@@ -31,9 +30,12 @@
                 <td style="width:120px"><a href="#!viewRecorder/{{ recorder._id }}">{{recorder.name}}</a></td>
                 <td style="width:120px">{{recorder.sut.name}}</td>
                 <td>{{recorder.protocol}}</td>
-                <td>{{recorder.active}}</td>
                 <td class="urlmax">{{ mockiatoHost + '/recording/live/' + recorder.sut.name + recorder.path }}</td>
-                <td><button class="btn btn-default" title="Delete recorder" ng-click="deleteRecording(recorder)"><i class="glyphicon glyphicon-trash"></i></button></td>
+                <td>
+                    <button class="btn btn-danger"  ng-show="recorder.running === true" ng-click="stopRecorder(recorder)">Stop <i class="glyphicon glyphicon-stop"></i></button>
+                    <button class="btn btn-success" ng-show="recorder.running === false" ng-click="startRecorder(recorder)">Start <i class="glyphicon glyphicon-play"></i></button>
+                    <button class="btn btn-default" title="Delete recorder" ng-click="deleteRecording(recorder)"><i class="glyphicon glyphicon-trash"></i></button>
+                </td>
             </tr>
         </table>
     </div>

--- a/routes/recording.js
+++ b/routes/recording.js
@@ -60,3 +60,8 @@ apiRouter.put("/",recordController.addRecorder);
 
 //Remove a recorder
 apiRouter.delete("/:id",recordController.removeRecorder);
+
+
+//Start and stop recorder
+apiRouter.patch("/:id/start",recordController.startRecorder);
+apiRouter.patch("/:id/stop",recordController.stopRecorder);


### PR DESCRIPTION
Recorders can now be stopped/started. 

Added two api calls: 
/api/recorder/{id}/start
/api/recorder/{id}/stop

Added buttons on recorder browse page to start/stop. 

Additionally, application will start all recorders on boot if they are marked running. 