### PR TITLE
Added browsing history for back button to /fetchservices.

### DIFF
--- a/public/js/app/app.js
+++ b/public/js/app/app.js
@@ -98,9 +98,10 @@ var mockapp = angular.module('mockapp',['mockapp.controllers','mockapp.services'
                 }
             })
 
-            .when("/fetchservices", {
+            .when("/fetchservices/:sut?/:user?", {
                 templateUrl: "partials/servicehistory.html",
                 controller: "serviceHistoryController",
+                reloadOnUrl: false,
                 resolve: {
                     auth: ['$q', 'authService', function($q, authService) {
                         var userInfo = authService.getUserInfo();

--- a/public/js/app/services.js
+++ b/public/js/app/services.js
@@ -761,6 +761,22 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
                 return sutlist;
             };
 
+            this.getAllSUTPromise = function(){
+              return new Promise(function(resolve,reject){
+                $http.get('/api/systems').then(function(response){
+                  var sutlist = [];
+                  response.data.forEach(function(sutData) {
+                    var sut = {
+                      name: sutData.name
+                    };
+                   
+                    sutlist.push(sut);
+                  });
+                  resolve(sutlist);
+              });
+            });
+          };
+
           this.getGroupsToBeDeleted = function(user){
               var deleteSutList = sutFactory.getGroupsToBeDeleted(user);
               return deleteSutList;
@@ -1100,11 +1116,22 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
 
     }])
 
-    .service('userService', ['userFactory',
-        function(userFactory) {
+    .service('userService', ['userFactory','$http',
+        function(userFactory,$http) {
             this.getAllUsers = function() {
                 return userFactory.getAllUsers();
             };
+            this.getAllUsersPromise = function() {
+              return new Promise(function(resolve,reject){
+                $http.get('/api/users').then(function(response){
+                  var userlist = [];
+                  response.data.forEach(function(userData){
+                    userlist.push({name:userData.uid});
+                  });
+                  resolve(userlist);
+                });
+              });
+          };
     }])
 
     .service('suggestionsService', ['statusCodesFactory', 'headersFactory',

--- a/public/partials/servicehistory.html
+++ b/public/partials/servicehistory.html
@@ -8,7 +8,7 @@
             <select class="form-control" id="system_under_test" title="Select SUT" ng-model="selectedSut" ng-options="sut.name for sut in sutlist | orderBy:'name'"></select>
             <label for="system_under_test">Owner:</label>
             <select class="form-control" id="user" title="Select Owner" ng-model="selectedUser" ng-options="user.name for user in userlist | orderBy:'name'"></select>&nbsp;
-            <button type="submit" class="btn btn-primary" ng-click="filtersSelected(selectedSut, selectedUser)">Find</button>&nbsp;
+            <button type="submit" class="btn btn-primary" ng-click="filtersSelected(selectedSut, selectedUser); buttonHit = true;">Find</button>&nbsp;
             <button type="submit" class="btn btn-default" ng-click="clearSelected()">Clear</button>
         </div>
         <!--to remove-->


### PR DESCRIPTION
the /fetchservices page will now track history as the user changes filters, enabling them to use back/forward navigation properly. Additionally, the filters can be access via path parameters:

/fetchservices/:sut/:user