### PR TITLE
Match Template Conditions

### DIFF
--- a/controllers/matchTemplateController.js
+++ b/controllers/matchTemplateController.js
@@ -1,6 +1,11 @@
 const xml2js = require('xml2js');
 const debug = require('debug')('matching');
 
+/**
+ * Applies all template options to a response string. E.g. puts out map values
+ * @param {*} response 
+ * @param {*} templateOptions 
+ */
 function applyTemplateOptionsToResponse(response,templateOptions){
 
     if(templateOptions.map){
@@ -15,8 +20,8 @@ function applyTemplateOptionsToResponse(response,templateOptions){
 
 /**
  * Merges a newly returned options object from processCondition() into the existing options
- * @param {*} oldOptions 
- * @param {*} newOptions 
+ * @param {*} oldOptions Old options- this gets mut'd!
+ * @param {*} newOptions new options
  */
 function mergeInOptions(oldOptions,newOptions){
     if(typeof newOptions == 'object'){
@@ -103,6 +108,15 @@ function preProcessCondition(field,conditionString,flatPayload){
     return opts;
 }
 
+
+/**
+ * Tests a payload against a request using a template. Returns any template options that were parsed (e.g. mapping vars)
+ * @param {*} flatTemplate The flattened template
+ * @param {*} rrpair RR Pair in question
+ * @param {*} flatPayload Flattened payload
+ * @param {*} flatReqData Flattened reqData from RR pair
+ * @param {*} path Path of this req (for debug logging)
+ */
 function matchOnTemplate(flatTemplate,rrpair,flatPayload,flatReqData,path){
     var returnOptions = {};
     const trimmedPayload = {}; const trimmedReqData = {};
@@ -140,6 +154,12 @@ function matchOnTemplate(flatTemplate,rrpair,flatPayload,flatReqData,path){
 }
 
 
+/**
+ * Given a template and the payload type, parse this template and flatten it.
+ * @param {*} template 
+ * @param {*} payloadType 
+ * @return Flattened template, or false if parsing fails. 
+ */
 function parseAndFlattenTemplate(template,payloadType){
     if (payloadType === 'XML') {
         xml2js.parseString(template, function(err, xmlTemplate) {

--- a/controllers/matchTemplateController.js
+++ b/controllers/matchTemplateController.js
@@ -103,32 +103,9 @@ function preProcessCondition(field,conditionString,flatPayload){
     return opts;
 }
 
-function matchOnTemplate(template,rrpair,payload,reqData,path){
+function matchOnTemplate(flatTemplate,rrpair,flatPayload,flatReqData,path){
     var returnOptions = {};
-    if (rrpair.payloadType === 'XML') {
-        xml2js.parseString(template, function(err, xmlTemplate) {
-          if (err) {
-            logEvent(err);
-            return false;
-          }
-          template = xmlTemplate;
-        });
-      }
-      else if (rrpair.payloadType === 'JSON') {
-        try {
-          template = JSON.parse(template);
-        }
-        catch(e) {
-          debug(e);
-          return false;
-        }
-      }
-
-      const flatTemplate = flattenObject(template);
-      const flatPayload  = flattenObject(payload);
-      const flatReqData  = flattenObject(reqData);
-
-      const trimmedPayload = {}; const trimmedReqData = {};
+    const trimmedPayload = {}; const trimmedReqData = {};
       var hasBlank = false;
       for (let field in flatTemplate) {
 
@@ -163,9 +140,34 @@ function matchOnTemplate(template,rrpair,payload,reqData,path){
 }
 
 
+function parseAndFlattenTemplate(template,payloadType){
+    if (payloadType === 'XML') {
+        xml2js.parseString(template, function(err, xmlTemplate) {
+            if (err) {
+                logEvent(err);
+                return false;
+            }
+            return flattenObject(xmlTemplate);
+        });
+    }
+    else if (payloadType === 'JSON') {
+        try {
+            return flattenObject(JSON.parse(template));
+        }
+        catch(e) {
+            debug(e);
+            return false;
+        }
+    }else{
+        return false;
+    }
+
+}
+
 
 module.exports = {
     matchOnTemplate : matchOnTemplate,
     applyTemplateOptionsToResponse:applyTemplateOptionsToResponse,
-    preProcessCondition:preProcessCondition
+    preProcessCondition:preProcessCondition,
+    parseAndFlattenTemplate: parseAndFlattenTemplate
 }

--- a/controllers/matchTemplateController.js
+++ b/controllers/matchTemplateController.js
@@ -1,4 +1,39 @@
+const xml2js = require('xml2js');
+const debug = require('debug')('matching');
+
+function mergeInOptions(oldOptions,newOptions){
+    for(let key1 in newOptions){
+        if(oldOptions[key1]){
+            if(Array.isArray(oldOptions[key1])){
+                oldOptions[key1] = oldOptions[key1].concat(newOptions[key1]);
+            }else if(typeof oldOptions == 'object'){
+                for(let key2 in newOptions[key1]){
+                    oldOptions[key1][key2] = newOptions[key1][key2];
+                }
+            }else{
+                oldOptions[key1] = newOptions[key1];
+            }
+        }else{
+            oldOptions[key1] = newOptions[key1];
+        }
+    }
+}
+
+
+function processCondition(field,conditionString,flatPayload){
+    var split = conditionString.split(":",2);
+    switch(split[0]){
+        case "map":
+            var map = {};
+            map[split[1]] = flatPayload[field];
+            return {map};
+        default:
+            return false;
+    }
+}
+
 function matchOnTemplate(template,rrpair,payload,reqData,path){
+    var returnOptions = {};
     if (rrpair.payloadType === 'XML') {
         xml2js.parseString(template, function(err, xmlTemplate) {
           if (err) {
@@ -14,6 +49,7 @@ function matchOnTemplate(template,rrpair,payload,reqData,path){
         }
         catch(e) {
           debug(e);
+          return false;
         }
       }
 
@@ -22,22 +58,37 @@ function matchOnTemplate(template,rrpair,payload,reqData,path){
       const flatReqData  = flattenObject(reqData);
 
       const trimmedPayload = {}; const trimmedReqData = {};
-        
+      var hasCondition = false;
       for (let field in flatTemplate) {
-        trimmedPayload[field] = flatPayload[field];
-        trimmedReqData[field] = flatReqData[field];
+
+        //If we have a condition here, handle its special properties
+        if(flatTemplate[field]){
+            var ret = processCondition(field,flatTemplate[field],flatPayload);
+            if(ret !== false){
+                mergeInOptions(returnOptions,ret);
+                hasCondition = true;
+            }else{
+                return false;
+            }
+        //Otherwise add this to the list to get literal equals'd
+        }else{
+            trimmedPayload[field] = flatPayload[field];
+            trimmedReqData[field] = flatReqData[field];
+        }
       }
       
       logEvent(path, rrpair.label, 'received payload (from template): ' + JSON.stringify(trimmedPayload, null, 2));
       logEvent(path, rrpair.label, 'expected payload (from template): ' + JSON.stringify(trimmedReqData, null, 2));
 
-      match = deepEquals(trimmedPayload, trimmedReqData);
+      if(!deepEquals(trimmedPayload, trimmedReqData)){
+          return false;
+      }
 
       // make sure we're not comparing {} == {}
-      if (match && JSON.stringify(trimmedPayload) === '{}') {
-        match = false;
+      if (!hasCondition && JSON.stringify(trimmedPayload) === '{}') {
+        return false;
       }
-      return match;
+      return returnOptions;
 }
 
 

--- a/controllers/matchTemplateController.js
+++ b/controllers/matchTemplateController.js
@@ -1,6 +1,23 @@
 const xml2js = require('xml2js');
 const debug = require('debug')('matching');
 
+function applyTemplateOptionsToResponse(response,templateOptions){
+
+    if(templateOptions.map){
+        for(let key in templateOptions.map){
+            response = response.replace("{{" + key + "}}",templateOptions.map[key]);
+        }
+    }
+    return response;
+}
+
+
+
+/**
+ * Merges a newly returned options object from processCondition() into the existing options
+ * @param {*} oldOptions 
+ * @param {*} newOptions 
+ */
 function mergeInOptions(oldOptions,newOptions){
     for(let key1 in newOptions){
         if(oldOptions[key1]){
@@ -20,6 +37,13 @@ function mergeInOptions(oldOptions,newOptions){
 }
 
 
+/**
+ * Given a condition string, process this condition.
+ * @param {string} field Flattened field name (e.g. "params.person.firstName")
+ * @param {string} conditionString The condition string (e.g. map:firstName)
+ * @param {object} flatPayload  Flattened payload
+ * @return Returns either an object that contains new options for the template, OR false if the condition is considered failed. ONLY false is considered a failure- {} or null is a pass!
+ */
 function processCondition(field,conditionString,flatPayload){
     var split = conditionString.split(":",2);
     switch(split[0]){
@@ -27,8 +51,10 @@ function processCondition(field,conditionString,flatPayload){
             var map = {};
             map[split[1]] = flatPayload[field];
             return {map};
-        default:
+        case "failMe": //Temporary to make DeepScan happy. 
             return false;
+        default:
+            return {};
     }
 }
 
@@ -94,5 +120,6 @@ function matchOnTemplate(template,rrpair,payload,reqData,path){
 
 
 module.exports = {
-    matchOnTemplate : matchOnTemplate
+    matchOnTemplate : matchOnTemplate,
+    applyTemplateOptionsToResponse:applyTemplateOptionsToResponse
 }

--- a/controllers/matchTemplateController.js
+++ b/controllers/matchTemplateController.js
@@ -1,0 +1,47 @@
+function matchOnTemplate(template,rrpair,payload,reqData,path){
+    if (rrpair.payloadType === 'XML') {
+        xml2js.parseString(template, function(err, xmlTemplate) {
+          if (err) {
+            logEvent(err);
+            return false;
+          }
+          template = xmlTemplate;
+        });
+      }
+      else if (rrpair.payloadType === 'JSON') {
+        try {
+          template = JSON.parse(template);
+        }
+        catch(e) {
+          debug(e);
+        }
+      }
+
+      const flatTemplate = flattenObject(template);
+      const flatPayload  = flattenObject(payload);
+      const flatReqData  = flattenObject(reqData);
+
+      const trimmedPayload = {}; const trimmedReqData = {};
+        
+      for (let field in flatTemplate) {
+        trimmedPayload[field] = flatPayload[field];
+        trimmedReqData[field] = flatReqData[field];
+      }
+      
+      logEvent(path, rrpair.label, 'received payload (from template): ' + JSON.stringify(trimmedPayload, null, 2));
+      logEvent(path, rrpair.label, 'expected payload (from template): ' + JSON.stringify(trimmedReqData, null, 2));
+
+      match = deepEquals(trimmedPayload, trimmedReqData);
+
+      // make sure we're not comparing {} == {}
+      if (match && JSON.stringify(trimmedPayload) === '{}') {
+        match = false;
+      }
+      return match;
+}
+
+
+
+module.exports = {
+    matchOnTemplate : matchOnTemplate
+}

--- a/controllers/matchTemplateController.js
+++ b/controllers/matchTemplateController.js
@@ -162,13 +162,15 @@ function matchOnTemplate(flatTemplate,rrpair,flatPayload,flatReqData,path){
  */
 function parseAndFlattenTemplate(template,payloadType){
     if (payloadType === 'XML') {
+        let ret = false;
         xml2js.parseString(template, function(err, xmlTemplate) {
             if (err) {
                 logEvent(err);
-                return false;
+                ret = false;
             }
-            return flattenObject(xmlTemplate);
+            ret =  flattenObject(xmlTemplate); 
         });
+        return ret; 
     }
     else if (payloadType === 'JSON') {
         try {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -160,6 +160,17 @@ if (!Object.entries)
 };
 
 
+global.logEvent = function(path, label, msg) {
+  debug(path, label, msg);
+
+  let event = {};
+  event.path = path;
+  event.label = label;
+  event.msg = msg;
+
+  logger.info(event);
+}
+
 global.escapeRegExp = function(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }

--- a/public/js/app/controllers.js
+++ b/public/js/app/controllers.js
@@ -27,8 +27,8 @@ var ctrl = angular.module("mockapp.controllers",['mockapp.services','mockapp.fac
       };
     }])
 
-    .controller("myMenuAppController", ['$scope', 'apiHistoryService', 'sutService', 'authService', 'suggestionsService', 'helperFactory', 'ctrlConstants', 
-      function ($scope, apiHistoryService, sutService,authService,suggestionsService,helperFactory,ctrlConstants){
+    .controller("myMenuAppController", ['$scope', 'apiHistoryService', 'sutService', 'authService', 'suggestionsService', 'helperFactory', 'ctrlConstants','modalService',
+      function ($scope, apiHistoryService, sutService,authService,suggestionsService,helperFactory,ctrlConstants,modalService){
             $scope.myUser = authService.getUserInfo().username;
             $scope.sutlist = sutService.getGroupsByUser($scope.myUser);
             $scope.servicevo = {};
@@ -171,6 +171,10 @@ var ctrl = angular.module("mockapp.controllers",['mockapp.services','mockapp.fac
                }); 
             }
           };
+          $scope.showTemplateHelp = function(){
+            modalService.showTemplateHelp();
+          
+        }
     }])
 
     .controller("createRecorderController", ['$scope', 'apiHistoryService', 'sutService', 'authService', 'suggestionsService', 'helperFactory', 'ctrlConstants', 
@@ -1282,8 +1286,8 @@ var ctrl = angular.module("mockapp.controllers",['mockapp.services','mockapp.fac
       });
       $scope.pollForRRPairs();
      }])   
-    .controller("updateController", ['$scope', '$q', '$http', '$routeParams', 'apiHistoryService', 'feedbackService', 'suggestionsService', 'helperFactory', 'ctrlConstants', 'sutService', 'authService',"$location",
-        function ($scope, $q, $http, $routeParams, apiHistoryService, feedbackService, suggestionsService, helperFactory, ctrlConstants, sutService, authService,$location) {    
+    .controller("updateController", ['$scope', '$q', '$http', '$routeParams', 'apiHistoryService', 'feedbackService', 'suggestionsService', 'helperFactory', 'ctrlConstants', 'sutService', 'authService',"$location",'modalService',
+        function ($scope, $q, $http, $routeParams, apiHistoryService, feedbackService, suggestionsService, helperFactory, ctrlConstants, sutService, authService,$location,modalService) {    
           
           $scope.statusCodes = suggestionsService.getStatusCodes();
             $scope.possibleHeaders = suggestionsService.getPossibleHeaders();
@@ -1633,6 +1637,10 @@ var ctrl = angular.module("mockapp.controllers",['mockapp.services','mockapp.fac
             $scope.totalDisplayed += 10;
           };
 
+          $scope.showTemplateHelp = function(){
+              modalService.showTemplateHelp();
+            
+          }
           //To Show Service Success Modal when a new service is created.
           if($routeParams.frmWher=='frmServCreate'){
             $http.get('/api/services/' + $routeParams.id)
@@ -1650,6 +1658,8 @@ var ctrl = angular.module("mockapp.controllers",['mockapp.services','mockapp.fac
               });
             $('#success-modal').modal('toggle');
           }
+
+
     }])
 
     .controller("selectServiceController", ['$scope', 'apiHistoryService','authService',

--- a/public/js/app/services.js
+++ b/public/js/app/services.js
@@ -1,5 +1,19 @@
 var serv = angular.module('mockapp.services',['mockapp.factories'])
 
+    .service('modalService',['$http','$rootScope','servConstants',
+    function($http,$rootScope,servConstants){
+      function setRemoteModal(title,remoteBodyLocation,footer){
+        $http.get(remoteBodyLocation).then(function(rsp){
+          $('#genricMsg-dialog').find('.modal-title').text(title);
+          $('#genricMsg-dialog').find('.modal-body').html(rsp.data);
+          $('#genricMsg-dialog').find('.modal-footer').html("");
+          $('#genricMsg-dialog').modal('toggle');
+        });
+      }
+      this.showTemplateHelp = function(){
+        setRemoteModal(servConstants.MCH_HELP_TITLE,"/partials/modals/templateHelpModal.html","");
+      }
+    }])
     .service('authService', ['$http', '$window', '$location', '$rootScope', 'servConstants', 
         function($http, $window, $location, $rootScope, servConstants) {
             var userInfo;
@@ -1218,5 +1232,6 @@ serv.constant("servConstants", {
         "DUP_RECORDER_PATH_TITLE" : "Publish Failure: Duplicate Path",
         "SERVICE_SAVE_FAIL_ERR_TITLE" : "Service Info Failure",
         "SERVICE_SAVE_FAIL_ERR_BODY": "Service Info save as draft failed",
-        "BACK_DANGER_BTN_FOOTER" : '<button type="button" data-dismiss="modal" class="btn btn-danger">Back</button>'
+        "BACK_DANGER_BTN_FOOTER" : '<button type="button" data-dismiss="modal" class="btn btn-danger">Back</button>',
+        "MCH_HELP_TITLE" : "Match Templates Help"
       });

--- a/public/partials/addapiform.html
+++ b/public/partials/addapiform.html
@@ -68,10 +68,16 @@
       <div class="col-xs-9">
         <fieldset data-ng-repeat="template in servicevo.matchTemplates">
           <div class="row">
-            <div class="col-xs-10">
+            <div class="col-xs-9">
               <textarea class="form-control vertResize" ng-model="template.val" placeholder="Define a template for request matching"></textarea><br>
             </div>
-  
+
+            <div class="col-xs-1">
+              <button class="btn btn-info" title="Service Info" ng-click="showTemplateHelp()" ng-show="$first">
+                <i class="glyphicon glyphicon-question-sign"></i> 
+              </button>
+            </div>
+            
             <div class="col-xs-1">
               <button type="button" class="btn btn-warning" ng-show="$last && !$first" ng-click="removeTemplate($index)">
                 <span class="glyphicon glyphicon-minus"></span>

--- a/public/partials/modals/templateHelpModal.html
+++ b/public/partials/modals/templateHelpModal.html
@@ -1,0 +1,201 @@
+<p>
+    Matching templates allow the user to select which fields Mockiato should attempt to match on, and/or provide specific conditions
+    for if a field is considered to have matched.
+</p>
+<h3>Template structure</h3>
+<p>
+    A matching template should mirror the incoming request in structure, but only include fields that you wish Mockiato to attempt
+    to match on. E.g. if your incoming request looks like:
+    <pre>
+        <code>
+            {
+                "abc":"def",
+                "foo":"bar"
+            }
+        </code>
+    </pre> But you only want to match on the "abc" field, ignoring "foo", you could construct a matching template as such:
+    <pre>
+        <code>
+            {
+                "abc":""
+            }
+        </code>
+    </pre> Then, Mockiato will ONLY attempt to match on "abc", so any of these requests would work:
+    <pre>
+        <code>
+            {
+                "abc":"def"
+            }
+        </code>
+    </pre>
+    <pre>
+        <code>
+            {
+                "abc":"def",
+                "foo":"bar"
+            }
+        </code>
+    </pre>
+    <pre>
+        <code>
+            {
+                "abc":"def",
+                "foo":"123",
+                "nonsense","argument"
+            }
+        </code>
+    </pre>
+</p>
+<h3>Conditions</h3>
+<p>Conditions are tests that Mockiato can apply to specific fields during matching- for instance, Mockiato can use the 'any' condition to test only that a field is present, but not test its value, or the 'lt' condition to test that a field's value is less than a given value. This is done by filling the value of a field with a 'condition string'. This string can contain one or more conditions, separated by a semicolon, ";". The argument passed to the condition is seperated by a colon, ":". A field is only considered matched if ALL conditions provided are matched.</p>
+<pre>
+    <code>
+        {
+            "abc":"lt:4"
+        }
+    </code>
+</pre>
+<h4>List of conditions</h4>
+<table class="table">
+    <tr>
+        <th>
+            Condition
+        </th>
+        <th>
+            Name
+        </th>
+        <th>
+            Argument
+        </th>
+        <th>
+            Description
+        </th>
+    </tr>
+    <tr>
+        <td>
+            lt
+        </td>
+        <td>
+            Less Than
+        </td>
+        <td>
+            A number
+        </td>
+        <td>
+            This condition evaluates true if and only if the request's value for this field is less than the argument provided.
+        </td>
+    </tr>
+    <tr>
+        <td>
+            gt
+        </td>
+        <td>
+            Greater Than
+        </td>
+        <td>
+            A number
+        </td>
+        <td>
+            This condition evaluates true if and only if the request's value for this field is greater than the argument provided.
+        </td>
+    </tr>
+    <tr>
+        <td>
+            any
+        </td>
+        <td>
+            Any
+        </td>
+        <td>
+            none
+        </td>
+        <td>
+            This condition evaluates true if and only if the field is present in the request. No further evaluation is made (any value may be passed)
+        </td>
+    </tr>
+    <tr>
+        <td>
+            regex
+        </td>
+        <td>
+            Regular Expression
+        </td>
+        <td>
+            A javascript regular expression
+        </td>
+        <td>
+            This condition evaluates true if and only if the request's value for this field CONTAINS an expression that matches this regular expression (This means if you want an exact, complete match, you will need to use ^ and $)
+        </td>
+    </tr>
+    <tr>
+        <td>
+            map
+        </td>
+        <td>
+            Map value
+        </td>
+        <td>
+            A parameter name
+        </td>
+        <td>
+            This condition always evaluates true. Additionally, it takes the incoming request value and maps it to a parameter name, which can then be used to reference this value to echo it in the response Mockiato gives to the user. NOTE: This ALWAYS resolves true. If you want to ensure this field is present, pair with the 'any' condition.
+        </td>
+    </tr>
+</table>
+<h4>Value Mapping</h4>
+<p>Using the 'Map' condition, Mockiato can map values from the request to the response dynamically. This is done by giving a parameter name to the map condition to save a value from the request to. Then, template tags are used in the configured response, as: {{parameterName}}</p>
+<p>For instance, if your request looked like:</p>
+<pre>
+        <code>
+            {
+                "abc":"def",
+                "foo":"bar"
+            }
+        </code>
+    </pre>
+
+<p>And your response like:</p>
+
+<pre>
+    <code>
+        {
+            "firstName":"Bob",
+            "lastName":"Johnson"
+        }
+    </code>
+</pre>
+
+<p>And you wanted to map the value of 'abc' in the request to the value of 'firstName' in the response, you would set up a matching template like this:</p>
+
+<pre>
+    <code>
+        {
+            "abc":"map:fname",
+            "foo":""
+        }
+    </code>
+</pre>
+
+<p>And a response like this:</p>
+
+<pre>
+    <code>
+        {
+            "firstName":"{{fname}}",
+            "lastName":"Johnson"
+        }
+    </code>
+</pre>
+
+<p>Then, any value for 'abc' will be accepted, and mapped into the value of firstName in the response.</p>
+
+<h4>Multiple Conditions</h4>
+<p>Mockiato can evaluate multiple conditions on each field. To do this, just separate your conditions by a semicolon- ";". Each condition must evaluate true for this field to be considered a match. For example, if you wanted to use regular expressions to make sure a field was a valid Social Security Number, AND wanted to map its value to the response, you could do:</p>
+<pre>
+    <code>
+        {
+            "ssn":"regex:^[0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9]$;map:ssn"
+        }
+    </code>
+</pre>
+<p>Then, any field will be evaluated against the regular expression, AND be mapped to the parameter name 'ssn'.</p>

--- a/public/partials/updateForm.html
+++ b/public/partials/updateForm.html
@@ -70,10 +70,15 @@
     <div class="col-xs-9">
       <fieldset data-ng-repeat="template in servicevo.matchTemplates">
         <div class="row">
-          <div class="col-xs-10">
+          <div class="col-xs-9">
             <textarea class="form-control vertResize" ng-model="template.val" placeholder="Define a template for request matching"></textarea><br>
           </div>
 
+          <div class="col-xs-1">
+            <button class="btn btn-info" title="Service Info" ng-click="showTemplateHelp()" ng-show="$first">
+              <i class="glyphicon glyphicon-question-sign"></i> 
+            </button>
+          </div>
           <div class="col-xs-1">
             <button type="button" class="btn btn-warning" ng-show="$last && !$first" ng-click="removeTemplate($index)">
               <span class="glyphicon glyphicon-minus"></span>

--- a/routes/virtual.js
+++ b/routes/virtual.js
@@ -166,7 +166,7 @@ function registerRRPair(service, rrpair) {
           //Give .send a buffer instead of a string so it won't yell at us about content-types
 
 
-          let resString = typeof rrpair.resData == "object" ? JSON.stringify(rrpair.resData) : rrpair.resdata;
+          let resString = typeof rrpair.resData == "object" ? JSON.stringify(rrpair.resData) : rrpair.resData;
 
           //Handle template mapping
           if(templateOptions){

--- a/routes/virtual.js
+++ b/routes/virtual.js
@@ -48,7 +48,7 @@ function registerRRPair(service, rrpair) {
     var processRRPair = function(){
       req.msgContainer = req.msgContainer || {};
       req.msgContainer.reqMatched = false;
-
+      delete req._Mockiato_Flat_ReqData;
       if (req.method === rrpair.verb) {
         // convert xml to js object
         if (rrpair.payloadType === 'XML') {

--- a/routes/virtual.js
+++ b/routes/virtual.js
@@ -4,7 +4,6 @@ const xml2js = require('xml2js');
 const debug = require('debug')('matching');
 const Service = require('../models/http/Service');
 const removeRoute = require('../lib/remove-route');
-const logger = require('../winston');
 const invoke = require('./invoke');
 const matchTemplateController = require('../controllers/matchTemplateController');
 


### PR DESCRIPTION
Mockiato can now use 'conditions' in matching templates. These allow mockiato to perform matching on requests beyond strict literal equals comparisons. Additionally, Mockiato can now map data from requests into responses. Full documentation of this can be found in the help button next to the matching templates.

Included in this PR:

- Match template conditions
- Req->Res value mapping
- Performance optimizations for template parsing/flattening
- Help dialog for template 
- New modal service for pulling remote html for help modals