### PR TITLE
Archive Service detail page should not show message "you can't edit service."

### DIFF
--- a/public/js/app/controllers.js
+++ b/public/js/app/controllers.js
@@ -533,15 +533,18 @@ var ctrl = angular.module("mockapp.controllers", ['mockapp.services', 'mockapp.f
                     }
                   });
                 });
-                $scope.canEdit = function () {
-                  return false;
-                };
               })
-
               .catch(function (err) {
                 console.log(err);
               });
 
+              $scope.canEdit = function () {
+                return false;
+              };
+
+            if ($routeParams.frmWher == 'frmArchive') {
+              $scope.isFrmArchive = true;
+            }
             if (service.lastUpdateUser) {
               $scope.servicevo.lastUpdateUser = service.lastUpdateUser.uid;
             }

--- a/public/partials/updateForm.html
+++ b/public/partials/updateForm.html
@@ -1,5 +1,5 @@
 <h2>Update Mock Service</h2>
-<h4 ng-show="!canEdit()" class="text-info">You are unable to edit this service because you aren't part of the group "{{servicevo.sut.name}}". You can request access from the user: {{servicevo.lastUpdateUser}}.</h4>
+<h4 ng-show="!canEdit() && !isFrmArchive" class="text-info">You are unable to edit this service because you aren't part of the group "{{servicevo.sut.name}}". You can request access from the user: {{servicevo.lastUpdateUser}}.</h4>
 <fieldset ng-disabled="!canEdit()">
 <form name="form" ng-disabled="!canEdit()" class="well col-xs-12">
   <div class="form-group row">


### PR DESCRIPTION
The service detail page from archive services is showing error message that "you can't edit service". This will not be shown  here from Archive.