### PR TITLE
Bug fixes for XML and override header

### DIFF
--- a/routes/invoke.js
+++ b/routes/invoke.js
@@ -4,6 +4,7 @@ const removeRoute = require('../lib/remove-route');
 const requestNode = require('request');
 const Service = require('../models/http/Service');
 const timeBetweenTransactionUpdates = process.env.MOCKIATO_TRANSACTON_UPDATE_TIME || 5000;
+const xml2js = require("xml2js");
 
 var transactions = {};
 
@@ -69,6 +70,15 @@ function createRRPairFromReqRes(req,res,service){
         myRRPair.payloadType = "JSON";
     }else if(contentType == "text/xml" || contentType == "application/xml" || service.type == "SOAP"){
         myRRPair.payloadType = "XML";
+        xml2js.parseString(req.body, function (err, result) {
+            if(err)
+                myRRPair.payloadType = "PLAIN";
+            else
+            xml2js.parseString(res.body, function (err, result) {
+                if(err)
+                    myRRPair.payloadType = "PLAIN";
+            });
+        });
     }else{
         myRRPair.payloadType = "PLAIN";
     }

--- a/routes/virtual.js
+++ b/routes/virtual.js
@@ -278,8 +278,20 @@ function registerRRPair(service, rrpair) {
       }
     }
 
+    //Check for live invo override header
+    var override = req.get("_mockiato-use-live");
+    var overrideIsSet = false;
+    if(override){
+      if(service.liveInvocation.remoteHost != undefined && service.liveInvocation.remotePort != undefined){
+        override = override.toLowerCase() === "true";
+        overrideIsSet = true;
+      }else{
+        override = false;
+      }
+    }
+
     //If live invocation is enabled, and invoke first is selected, and we haven't run this yet...
-    if(service.liveInvocation && service.liveInvocation.enabled && service.liveInvocation.liveFirst &&  !req._mockiatoLiveInvokeHasRun){
+    if(((service.liveInvocation && service.liveInvocation.enabled && service.liveInvocation.liveFirst && !overrideIsSet) || (override && overrideIsSet)) &&  !req._mockiatoLiveInvokeHasRun){
       var prom = invoke.invokeBackendVerify(service,req);
       req._mockiatoLiveInvokeHasRun = true;
       prom.then(function(remoteRsp,remoteRspBody){


### PR DESCRIPTION
Fixed a bug where invalid XML was saved with XML payload type instead of plain

And

Added a request header option: _mockiato-use-live. If set to 'true', mockiato will attempt to do live-first  live invocation whether or not invocation is enabled (as long as a remote host and port have been configured). If set to any other value, it will count as false, and not attempt live invocation under any circumstances. If this header is NOT set, behavior will be as default. 

closes #361 