### PR TITLE
Duplicate queries + informative errors

### DIFF
--- a/public/js/app/controllers.js
+++ b/public/js/app/controllers.js
@@ -160,7 +160,7 @@ var ctrl = angular.module("mockapp.controllers", ['mockapp.services', 'mockapp.f
         }
         catch (e) {
           $('#genricMsg-dialog').find('.modal-title').text(ctrlConstants.PUB_FAIL_ERR_TITLE);
-          $('#genricMsg-dialog').find('.modal-body').text(ctrlConstants.PUB_FAIL_SERV_SAVE_BODY);
+          $('#genricMsg-dialog').find('.modal-body').text(e);
           $('#genricMsg-dialog').find('.modal-footer').html(ctrlConstants.PUB_FAIL_SERV_SAVE_FOOTER);
           $('#genricMsg-dialog').modal('toggle');
           $('#modal-btn-yes').on("click", function () {
@@ -476,7 +476,7 @@ var ctrl = angular.module("mockapp.controllers", ['mockapp.services', 'mockapp.f
         catch (e) {
           console.log(e);
           $('#genricMsg-dialog').find('.modal-title').text(ctrlConstants.PUB_FAIL_ERR_TITLE);
-          $('#genricMsg-dialog').find('.modal-body').text(ctrlConstants.PUB_FAIL_ERR_BODY);
+          $('#genricMsg-dialog').find('.modal-body').text(e);
           $('#genricMsg-dialog').find('.modal-footer').html(ctrlConstants.BACK_DANGER_BTN_FOOTER);
           $('#genricMsg-dialog').modal('toggle');
         }
@@ -941,7 +941,7 @@ var ctrl = angular.module("mockapp.controllers", ['mockapp.services', 'mockapp.f
         }
         catch (e) {
           $('#genricMsg-dialog').find('.modal-title').text(ctrlConstants.PUB_FAIL_ERR_TITLE);
-          $('#genricMsg-dialog').find('.modal-body').text(ctrlConstants.PUB_FAIL_SERV_SAVE_BODY);
+          $('#genricMsg-dialog').find('.modal-body').text(e);
           $('#genricMsg-dialog').find('.modal-footer').html(ctrlConstants.PUB_FAIL_SERV_SAVE_FOOTER);
           $('#genricMsg-dialog').modal('toggle');
           $('#modal-btn-yes').on("click", function () {
@@ -1612,7 +1612,7 @@ var ctrl = angular.module("mockapp.controllers", ['mockapp.services', 'mockapp.f
         }
         catch (e) {
           $('#genricMsg-dialog').find('.modal-title').text(ctrlConstants.PUB_FAIL_ERR_TITLE);
-          $('#genricMsg-dialog').find('.modal-body').text(ctrlConstants.PUB_FAIL_ERR_BODY);
+          $('#genricMsg-dialog').find('.modal-body').text(e);
           $('#genricMsg-dialog').find('.modal-footer').html(ctrlConstants.BACK_DANGER_BTN_FOOTER);
           $('#genricMsg-dialog').modal('toggle');
         }

--- a/public/js/app/services.js
+++ b/public/js/app/services.js
@@ -290,7 +290,7 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
                       }
                       catch(e) {
                         console.log(e);
-                        throw 'RR pair is malformed';
+                        throw 'JSON in an RR pair is malformed.';
                       }
                     }
                     // verify that XML is well formed
@@ -306,7 +306,7 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
                         resPayload = rr.responsepayload;
                       }
                       else {
-                        throw 'RR pair is malformed';
+                        throw 'XML in an RR Pair is malformed.';
                       }
                     }
                     else {
@@ -317,6 +317,8 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
                     // convert array of queries to object literal
                     var queries = {};
                     rr.queriesArr.forEach(function(q){
+                      if(queries[q.k])
+                        throw 'Duplicate Query Exists in an RR pair.';
                       queries[q.k] = q.v;
                     });
 


### PR DESCRIPTION
1) The UI should no longer allow duplicate query names (i.e. you cannot submit if you have two queries with the same name)

2) Error messages from a failed publish should now be more informative. The user will be displayed whatever message is thrown from the publish service. 

closes #387 