### PR TITLE
Fix for multi-service caching

### DIFF
--- a/routes/virtual.js
+++ b/routes/virtual.js
@@ -43,6 +43,11 @@ function registerRRPair(service, rrpair) {
   if (rrpair.label) label = rrpair.label;
 
   router.all(path, delay(service.delay, service.delayMax), function(req, resp, next) {
+    if(req._Mockiato_Last_Service_Id && req._Mockiato_Last_Service_Id != service.id){
+      delete req._Mockiato_Flat_Templates;
+    }
+    req._Mockiato_Last_Service_Id = service.id;
+
     //Function for handling incoming req against this RR pair
     var processRRPair = function(){
       req.msgContainer = req.msgContainer || {};


### PR DESCRIPTION
Should fix the issue of overlapping MQ services improperly caching templates. 