### PR TITLE
Disabled minimization on RRPair schema

### DIFF
--- a/models/http/RRPair.js
+++ b/models/http/RRPair.js
@@ -131,6 +131,6 @@ const rrSchema = new mongoose.Schema({
     type:Boolean,
     default:false
   }
-});
+},{minimize:false});
 
 module.exports = mongoose.model('RRPair', rrSchema);


### PR DESCRIPTION
Mongoose was optimizing storage by removing null/empty objects/fields. This made some rsps be saved in a way that was unexpected. I disabled this feature on the RRPair schema (has to be set on the schema level).

fixes #441 