### PR TITLE
Template from request

### DIFF
--- a/public/js/app/controllers/rrPairs.js
+++ b/public/js/app/controllers/rrPairs.js
@@ -37,20 +37,27 @@ var ctrl = angular.module("mockapp.controllers")
                * Creates a template from a given RR pair's request
                */
               $scope.makeTemplateFromRequest = function(rr){
-                if(rr.payloadType == "JSON"){
-                  console.log("doing it");
-                  let req = JSON.parse(rr.requestpayload);
-                  req = utilityService.emptyOutJSON(req);
-                  $scope.servicevo.matchTemplates.push({id:0,val:JSON.stringify(req,null,2)})
-                }else if(rr.payloadType == "XML"){
-                  let xml = rr.requestpayload;
-                  xml = xml.replace(/>[^<]+<\//g,"></");
-                  xml = utilityService.prettifyXml(xml);
-                  $scope.servicevo.matchTemplates.push({id:0,val:xml});
+                try{
+                  if(rr.payloadType == "JSON"){
+                    console.log("doing it");
+                    let req = JSON.parse(rr.requestpayload);
+                    req = utilityService.emptyOutJSON(req);
+                    $scope.servicevo.matchTemplates.push({id:0,val:JSON.stringify(req,null,2)})
+                  }else if(rr.payloadType == "XML"){
+                    let xml = rr.requestpayload;
+                    xml = xml.replace(/>[^<]+<\//g,"></");
+                    xml = utilityService.prettifyXml(xml);
+                    $scope.servicevo.matchTemplates.push({id:0,val:xml});
 
-                }else{
-                  console.log("not doig it");
-                  console.log(rr);
+                  }else{
+                    console.log("not doig it");
+                    console.log(rr);
+                  }
+                }catch(e){
+                  $('#genricMsg-dialog').find('.modal-title').text("Error creating matching template");
+                  $('#genricMsg-dialog').find('.modal-body').html(e.message);
+                  $('#genricMsg-dialog').find('.modal-footer').html("");
+                  $('#genricMsg-dialog').modal('toggle');
                 }
               }
 

--- a/public/js/app/controllers/rrPairs.js
+++ b/public/js/app/controllers/rrPairs.js
@@ -1,6 +1,6 @@
 var ctrl = angular.module("mockapp.controllers")
-  .controller("rrPairController", ['suggestionsService', '$scope', 'ctrlConstants','domManipulationService',
-    function (suggestionsService, $scope, ctrlConstants,domManipulationService){
+  .controller("rrPairController", ['suggestionsService', '$scope', 'ctrlConstants','domManipulationService','utilityService',
+    function (suggestionsService, $scope, ctrlConstants,domManipulationService,utilityService){
             $scope.addNewRRPair = function () {
                 var newItemNo = $scope.servicevo.rawpairs.length;
                 $scope.servicevo.rawpairs.push({
@@ -32,6 +32,27 @@ var ctrl = angular.module("mockapp.controllers")
                   $scope.$apply();
                 });
               };
+
+              /**
+               * Creates a template from a given RR pair's request
+               */
+              $scope.makeTemplateFromRequest = function(rr){
+                if(rr.payloadType == "JSON"){
+                  console.log("doing it");
+                  let req = JSON.parse(rr.requestpayload);
+                  req = utilityService.emptyOutJSON(req);
+                  $scope.servicevo.matchTemplates.push({id:0,val:JSON.stringify(req,null,2)})
+                }else if(rr.payloadType == "XML"){
+                  let xml = rr.requestpayload;
+                  xml = xml.replace(/>[^<]+<\//g,"></");
+                  xml = utilityService.prettifyXml(xml);
+                  $scope.servicevo.matchTemplates.push({id:0,val:xml});
+
+                }else{
+                  console.log("not doig it");
+                  console.log(rr);
+                }
+              }
 
               $scope.addNewReqHeader = function (rr) {
                 var newItemNo = rr.reqHeadersArr.length;

--- a/public/js/app/controllers/rrPairs.js
+++ b/public/js/app/controllers/rrPairs.js
@@ -39,7 +39,6 @@ var ctrl = angular.module("mockapp.controllers")
               $scope.makeTemplateFromRequest = function(rr){
                 try{
                   if(rr.payloadType == "JSON"){
-                    console.log("doing it");
                     let req = JSON.parse(rr.requestpayload);
                     req = utilityService.emptyOutJSON(req);
                     $scope.servicevo.matchTemplates.push({id:0,val:JSON.stringify(req,null,2)})
@@ -50,7 +49,6 @@ var ctrl = angular.module("mockapp.controllers")
                     $scope.servicevo.matchTemplates.push({id:0,val:xml});
 
                   }else{
-                    console.log("not doig it");
                     console.log(rr);
                   }
                 }catch(e){

--- a/public/js/app/services.js
+++ b/public/js/app/services.js
@@ -20,6 +20,47 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
         setRemoteModal(servConstants.INVOKE_HELP_TITLE,"/partials/modals/liveInvocationHelpModal.html","");
       }
     }])
+    .service('utilityService',[function(){
+      this.emptyOutJSON = function(jsonObject){
+        var jsonObject2 = jsonObject;
+        for (var key in jsonObject2){
+          if(jsonObject.hasOwnProperty(key)){
+            if(typeof jsonObject2[key] == "object")
+              if(Array.isArray(jsonObject[key]))
+                jsonObject2[key] = "";
+              else
+                jsonObject2[key] = this.emptyOutJSON(jsonObject2[key]);
+            else
+              jsonObject2[key] = "";
+          }
+        }
+        return jsonObject2;
+      };
+
+      this.prettifyXml = function(sourceXml)
+      {
+          var xmlDoc = new DOMParser().parseFromString(sourceXml, 'application/xml');
+          var xsltDoc = new DOMParser().parseFromString([
+              // describes how we want to modify the XML - indent everything
+              '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform">',
+              '  <xsl:strip-space elements="*"/>',
+              '  <xsl:template match="para[content-style][not(text())]">', // change to just text() to strip space in text nodes
+              '    <xsl:value-of select="normalize-space(.)"/>',
+              '  </xsl:template>',
+              '  <xsl:template match="node()|@*">',
+              '    <xsl:copy><xsl:apply-templates select="node()|@*"/></xsl:copy>',
+              '  </xsl:template>',
+              '  <xsl:output indent="yes"/>',
+              '</xsl:stylesheet>',
+          ].join('\n'), 'application/xml');
+      
+          var xsltProcessor = new XSLTProcessor();    
+          xsltProcessor.importStylesheet(xsltDoc);
+          var resultDoc = xsltProcessor.transformToDocument(xmlDoc);
+          var resultXml = new XMLSerializer().serializeToString(resultDoc);
+          return resultXml;
+      };
+    }])
     .service('domManipulationService',[function(){
       this.expandTextarea = function(ele){
         if(!ele._oldTransition)

--- a/public/partials/includes/rrPairs.html
+++ b/public/partials/includes/rrPairs.html
@@ -169,10 +169,13 @@
           </button>
         </div>
       </div>
-      <div class="form-group row">
-        <button type="button" class="btn btn-warning col-xs-1" ng-click="makeTemplateFromRequest(rr)">
-          <span class="glyphicon glyphicon-minus"></span>
-        </button>
+      <div class="form-group row" ng-show=" servicevo.type === 'SOAP' || rr.method!== 'GET' || servicevo.type === 'MQ'|| rr.getPayloadRequired">
+        <div class="col-xs-2"></div>
+        <div class=" col-xs-4">
+          <button type="button" class="btn btn-success" ng-click="makeTemplateFromRequest(rr)">
+            Create Matching Template from this Request
+          </button>
+        </div>
       </div>
 
 

--- a/public/partials/includes/rrPairs.html
+++ b/public/partials/includes/rrPairs.html
@@ -169,6 +169,11 @@
           </button>
         </div>
       </div>
+      <div class="form-group row">
+        <button type="button" class="btn btn-warning col-xs-1" ng-click="makeTemplateFromRequest(rr)">
+          <span class="glyphicon glyphicon-minus"></span>
+        </button>
+      </div>
 
 
       <div class="form-group row" ng-show="servicevo.type !== 'MQ'">


### PR DESCRIPTION
Added the ability to create matching template from a given  JSON or XML request.  When clicking the "Create Matching Template from this Request" button, a matching template is added, identical in structure to the associated request, but with all data elements blank. 

closes #118 