### PR TITLE
Fix for defect 476 and 477

### DIFF
--- a/public/js/app/controllers.js
+++ b/public/js/app/controllers.js
@@ -103,7 +103,7 @@ var ctrl = angular.module("mockapp.controllers", ['mockapp.services', 'mockapp.f
         servicevo.rawpairs.forEach(function(rrpair){  
           var i = rrpair.reqHeadersArr.length;
           while(i--){
-            if(rrpair.reqHeadersArr[i].k instanceof Object || rrpair.reqHeadersArr[i].k == ''){
+            if(!rrpair.reqHeadersArr[i].k || rrpair.reqHeadersArr[i].k == ''){
               rrpair.reqHeadersArr[i]={id: rrpair.reqHeadersArr[i].id};
             }
           }
@@ -816,7 +816,7 @@ var ctrl = angular.module("mockapp.controllers", ['mockapp.services', 'mockapp.f
         servicevo.rawpairs.forEach(function(rrpair){  
           var i = rrpair.reqHeadersArr.length;
           while(i--){
-            if(rrpair.reqHeadersArr[i].k instanceof Object || rrpair.reqHeadersArr[i].k == ''){
+            if(!rrpair.reqHeadersArr[i].k || rrpair.reqHeadersArr[i].k == ''){
               rrpair.reqHeadersArr[i]={id: rrpair.reqHeadersArr[i].id};
             }
           }
@@ -1415,7 +1415,7 @@ var ctrl = angular.module("mockapp.controllers", ['mockapp.services', 'mockapp.f
         servicevo.rawpairs.forEach(function(rrpair){  
           var i = rrpair.reqHeadersArr.length;
           while(i--){
-            if(rrpair.reqHeadersArr[i].k instanceof Object || rrpair.reqHeadersArr[i].k == ''){
+            if(!rrpair.reqHeadersArr[i].k || rrpair.reqHeadersArr[i].k == ''){
               rrpair.reqHeadersArr[i]={id: rrpair.reqHeadersArr[i].id};
             }
           }

--- a/public/js/app/services.js
+++ b/public/js/app/services.js
@@ -401,28 +401,36 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
                     // only save queries if there are any
                     if (Object.keys(queries).length > 0) {
                       rr.queries = queries;
+                    }else if(Object.keys(queries).length == 0){
+                      rr.queries = undefined;
                     }
 
                     // convert array of response headers to object literal
                     var resHeaders = {};
                     rr.resHeadersArr.forEach(function(headerObj){
+                      if(headerObj.k)
                       resHeaders[headerObj.k] = headerObj.v;
                     });
 
                     // only save headers if there are any
                     if (Object.keys(resHeaders).length > 0) {
                       rr.resHeaders = resHeaders;
+                    }else if(Object.keys(resHeaders).length == 0){
+                      rr.resHeaders = undefined;
                     }
 
                     // convert array of response headers to object literal
                     var reqHeaders = {};
                     rr.reqHeadersArr.forEach(function(headerObj){
+                      if(headerObj.k)
                       reqHeaders[headerObj.k] = headerObj.v;
                     });
 
                     // only save headers if there are any
                     if (Object.keys(reqHeaders).length > 0) {
                       rr.reqHeaders = reqHeaders;
+                    }else if(Object.keys(reqHeaders).length == 0){
+                      rr.reqHeaders = undefined;
                     }
                      // only save request data for non-GETs
                     if (rr.method !== 'GET') {


### PR DESCRIPTION
UI issued on req/res header and query parameters. 
1) When we remove all query params. Last query param don't get delete when we refresh.
2) When we remove all req/res headers. Last req/res header don't get delete when we refresh.