### PR TITLE
fix for issue 551.

### DIFF
--- a/routes/virtual.js
+++ b/routes/virtual.js
@@ -256,7 +256,9 @@ function registerRRPair(service, rrpair) {
           resp.send(new Buffer(resString));
         }
         else if (rrpair.resStatus && !rrpair.resData) {
-          resp.sendStatus(rrpair.resStatus);
+          resp.status(rrpair.resStatus);
+          //resp.sendStatus(rrpair.resStatus);
+          resp.send(new Buffer(""));
         }
         else {
           resp.sendStatus(200);


### PR DESCRIPTION
fix - issue related to blank response body with 201 (created) status code.   

Issue in mockiato is -- the content-type & content-length are coming as text/plain & 7 by default when I have a blank response and 201 response status code.