### PR TITLE
Open api spec small fixes

### DIFF
--- a/lib/openapi/parser.js
+++ b/lib/openapi/parser.js
@@ -72,7 +72,9 @@ function parse(spec) {
         // create one RR pair for each response
         const responses = Object.keys(spec.paths[path][method].responses);
         responses.forEach(function(resp) {
-          if (resp != 200) return;
+          // if (resp != 200) return;
+          // [1, 2, 3].includes(2)
+          if (['200', '201', '202'].includes(resp) === false) return;
 
           const rr = new RRPair();
           rr.path = path;
@@ -136,8 +138,9 @@ function parse(spec) {
           if (reqBodyObj) {
             const reqContent = reqBodyObj.content;
             if (reqContent) {
-              // TODO: need a better way of parsing media type
-              const reqMedType = 'application/json';
+              const result = Object.getOwnPropertyNames(reqContent);
+            // TODO: currently we only support single media type. There can be multi media types here.
+            const reqMedType = result[0];
               if (reqMedType) {
                 const reqSchema = reqBodyObj.content[reqMedType].schema;
                 rr.reqData = processSchema(reqSchema);
@@ -167,10 +170,13 @@ function parse(spec) {
           const responseObj = spec.paths[path][method].responses[resp];
           const contentObj = responseObj.content;
           if (contentObj) {          
-            // TODO: need a better way of parsing media type
-            const mediaType = 'application/json';
+            const result = Object.getOwnPropertyNames(contentObj);
+            // TODO: currently we only support single media type. There can be multi media types.
+            const mediaType = result[0];
+
             if (mediaType) {
               const resSchema = contentObj[mediaType].schema;
+              rr.resStatus = resp;
               rr.resData = processSchema(resSchema);
 
               if (!rr.payloadType) {
@@ -179,6 +185,7 @@ function parse(spec) {
             }
           }
           else {
+            rr.resStatus = resp;
             rr.resData = processSchema(responseObj);
           }
   

--- a/lib/openapi/parser.js
+++ b/lib/openapi/parser.js
@@ -72,8 +72,7 @@ function parse(spec) {
         // create one RR pair for each response
         const responses = Object.keys(spec.paths[path][method].responses);
         responses.forEach(function(resp) {
-          // if (resp != 200) return;
-          // [1, 2, 3].includes(2)
+
           if (['200', '201', '202'].includes(resp) === false) return;
 
           const rr = new RRPair();

--- a/public/js/app/services.js
+++ b/public/js/app/services.js
@@ -6,7 +6,7 @@ var serv = angular.module('mockapp.services',['mockapp.factories'])
         $http.get(remoteBodyLocation).then(function(rsp){
           $('#genricMsg-dialog').find('.modal-title').text(title);
           $('#genricMsg-dialog').find('.modal-body').html(rsp.data);
-          $('#genricMsg-dialog').find('.modal-footer').html("");
+          $('#genricMsg-dialog').find('.modal-footer').html(footer);
           $('#genricMsg-dialog').modal('toggle');
         });
       }

--- a/tests/test-draft.js
+++ b/tests/test-draft.js
@@ -153,7 +153,7 @@ describe('Search and Get Tests', function() {
             request
                 .get('/api/services/archive/' + id)
                 .expect(200,done);
-        });
+        }).timeout(10000);
         it('Gets the archived service via user',function(done){
             request
                 .get('/api/services/user/' + mockUser.username + '/archive')


### PR DESCRIPTION
(1) When we create a service from OpenApi Spec, We simply ignore the rrpairs with response status other than 200. I did allow the rrpairs with response status 201 (created) & 202 (Accepted). 

(2) Getting content-type was required to handle. It was hard coded as "application/json". Now I am getting it from Spec.